### PR TITLE
Updates

### DIFF
--- a/example.du
+++ b/example.du
@@ -30,7 +30,7 @@ class Role < kahless.Model {
         print("migrating table: {}".format(table._name));
 
         const err = k.migrate(table);
-        if (not Success(err)) {
+        if (not err.success()) {
             print("error: {}".format(err));
             System.exit(1);
         }

--- a/kahless.du
+++ b/kahless.du
@@ -98,7 +98,6 @@ def getTimestamp() {
  */
 def resultToClass(result, model) {
     const rows = result.unwrap();
-
 }
 
 /*
@@ -144,7 +143,7 @@ class Migrate < Validation {
         const klass = model._class;
 
         const err = this.verifyAnnotations(model, "Table", true);
-        if (not Success(err)) {
+        if (not err.success()) {
             return err;
         }
 
@@ -243,21 +242,16 @@ class Kahless < Validation {
         const tableName = model._class.classAnnotations.get("Table");
         var query = insertQuery.format(tableName);
 
-        const fields = model.getAttributes()["fields"].filter(def(x) => x != "_name");
+        const fields = model.getAttributes()["fields"].filter(def(x) => x != "_name" and not isModelField(x));
         const fieldsLen = fields.len();
         const fieldAnnotations = klass.fieldAnnotations;
 
         for (var i = 0; i < fieldsLen; i += 1) {
-            if (isModelField(fields[i])) {
-                continue;
-            }
-
-            if (fieldAnnotations.get(fields[i]) != nil) {
-                if (fieldAnnotations.get(fields[i]).exists("Column")) {
-                    query += fieldAnnotations.get(fields[i]).get("Column") + " ";
-                }
+            const separator = i + 1 == fieldsLen ? " " : ", ";
+            if (fieldAnnotations.get(fields[i])?.exists("Column")) {
+                query += fieldAnnotations.get(fields[i]).get("Column") + separator;
             } else {
-                query += fields[i] + " ";
+                query += fields[i] + separator;
             }
         }
 
@@ -265,10 +259,6 @@ class Kahless < Validation {
         query += ") VALUES (";
 
         for (var i = 0; i < fieldsLen; i += 1) {
-            if (isModelField(fields[i])) {
-                continue;
-            }
-
             var value = model.getAttribute(fields[i]);
             if (type(value) != "string") {
                 value = value.toString();
@@ -411,7 +401,7 @@ class Kahless < Validation {
         const klass = model._class;
 
         const err = this.verifyAnnotations(model, "Table", true);
-        if (not Success(err)) {
+        if (not err.success()) {
             return err;
         }
 
@@ -475,7 +465,7 @@ class Kahless < Validation {
         const klass = model._class;
         
         const err = this.verifyAnnotations(model, "Table", true);
-        if (not Success(err)) {
+        if (not err.success()) {
             return err;
         }
 
@@ -538,7 +528,7 @@ class Kahless < Validation {
         const klass = model._class;
 
         const err = this.verifyAnnotations(model, "Table", true);
-        if (not Success(err)) {
+        if (not err.success()) {
             return err;
         }
 

--- a/kahless.du
+++ b/kahless.du
@@ -268,7 +268,12 @@ class Kahless < Validation {
 
         query = query[0:query.len()-1];
         query += ")";
-        return this.db.execute(query);
+        const insert = this.db.execute(query);
+
+        const lastId = this.db.execute("SELECT LAST_INSERT_ROWID()").unwrap();
+        model.id = lastId[0][0];
+
+        return insert;
     }
 
     /* 
@@ -317,10 +322,8 @@ class Kahless < Validation {
                 continue;
             }
         
-            if (fieldAnnotations.get(fields[i]) != nil) {
-                if (fieldAnnotations.get(fields[i]).exists("Column")) {
-                    query += spaceSeperator + fieldAnnotations.get(fields[i]).get("Column");
-                }
+            if (fieldAnnotations.get(fields[i])?.exists("Column")) {
+                query += spaceSeperator + fieldAnnotations.get(fields[i]).get("Column");
             } else {
                 query += spaceSeperator + fields[i];
             }
@@ -374,7 +377,7 @@ class Kahless < Validation {
                 query += " id in ({})".format(ids);            
             }
             case "string": {
-                if (v.toNumber() < 0) {
+                if (v.toNumber().unwrap() < 0) {
                     return Error("invalid ID");
                 }
 

--- a/tests/runTests.du
+++ b/tests/runTests.du
@@ -3,3 +3,6 @@
  */
 import "./sqlite/migrate.du";
 import "./sqlite/create.du";
+import "./sqlite/update.du";
+import "./sqlite/delete.du";
+import "./sqlite/find.du";

--- a/tests/runTests.du
+++ b/tests/runTests.du
@@ -1,0 +1,5 @@
+/**
+ * SQLite tests
+ */
+import "./sqlite/migrate.du";
+import "./sqlite/create.du";

--- a/tests/sqlite/create.du
+++ b/tests/sqlite/create.du
@@ -1,0 +1,44 @@
+from UnitTest import UnitTest;
+
+import "../../kahless.du" as kahless;
+
+@Table("users")
+class User < kahless.Model {
+    @Column("first_name")
+    var firstName = "";
+
+    @Column("last_name")
+    var lastName = "";
+
+    @Column("age")
+    var age = 0;
+}
+
+@Table("roles")
+class Role < kahless.Model {
+    var name = "";
+}
+
+const config = kahless.Config("sqlite", ":memory:");
+const k = kahless.Kahless(config);
+
+class TestKahlessCreate < UnitTest {
+    setUp() {
+        const models = [User(), Role()];
+        k.migrate(...models);
+    }
+
+    testInsert() {
+        const user = User();
+        user.firstName = "John";
+        user.lastName = "Doe";
+        user.age = 28;
+
+        k.create(user);
+
+        const fetchedUser = k.rawQuery("SELECT first_name, last_name, age FROM users").unwrap();
+        this.assertEquals(fetchedUser[0], ["John", "Doe", "28"]);
+    }
+}
+
+TestKahlessCreate().run();

--- a/tests/sqlite/delete.du
+++ b/tests/sqlite/delete.du
@@ -1,0 +1,36 @@
+from UnitTest import UnitTest;
+
+import "../../kahless.du" as kahless;
+
+@Table("users")
+class User < kahless.Model {
+    @Column("first_name")
+    var firstName = "";
+
+    @Column("last_name")
+    var lastName = "";
+
+    @Column("age")
+    var age = 0;
+}
+
+@Table("roles")
+class Role < kahless.Model {
+    var name = "";
+}
+
+const config = kahless.Config("sqlite", ":memory:");
+const k = kahless.Kahless(config);
+
+class TestKahlessDelete < UnitTest {
+    setUp() {
+        const models = [User(), Role()];
+        k.migrate(...models);
+    }
+
+    testDelete() {
+        // TODO
+    }
+}
+
+TestKahlessDelete().run();

--- a/tests/sqlite/find.du
+++ b/tests/sqlite/find.du
@@ -1,0 +1,50 @@
+from UnitTest import UnitTest;
+
+import "../../kahless.du" as kahless;
+
+@Table("users")
+class User < kahless.Model {
+    @Column("first_name")
+    var firstName = "";
+
+    @Column("last_name")
+    var lastName = "";
+
+    @Column("age")
+    @Type("number")
+    var age = 0;
+}
+
+@Table("roles")
+class Role < kahless.Model {
+    var name = "";
+}
+
+const config = kahless.Config("sqlite", ":memory:");
+const k = kahless.Kahless(config);
+
+class TestKahlessFind < UnitTest {
+    setUp() {
+        const models = [User(), Role()];
+        k.migrate(...models);
+    }
+
+    testFind() {
+        const user = User();
+        user.firstName = "John";
+        user.lastName = "Doe";
+        user.age = 28;
+
+        k.create(user);
+
+        const users = k.find(User()).unwrap();
+
+        this.assertType(users, "Result");
+        this.assertType(users.rows, "list");
+        this.assertEquals(users.rows[0].firstName, "John");
+        this.assertEquals(users.rows[0].lastName, "Doe");
+        this.assertEquals(users.rows[0].age, 28);
+    }
+}
+
+TestKahlessFind().run();

--- a/tests/sqlite/migrate.du
+++ b/tests/sqlite/migrate.du
@@ -1,0 +1,41 @@
+from UnitTest import UnitTest;
+
+import "../../kahless.du" as kahless;
+
+@Table("users")
+class User < kahless.Model {
+    @Column("first_name")
+    var firstName = "";
+
+    @Column("last_name")
+    var lastName = "";
+
+    @Column("age")
+    var age = 0;
+}
+
+@Table("roles")
+class Role < kahless.Model {
+    var name = "";
+}
+
+const config = kahless.Config("sqlite", ":memory:");
+const k = kahless.Kahless(config);
+
+class TestKahlessMigrate < UnitTest {
+    testMigrate() {
+        const models = [User(), Role()];
+
+        models.forEach(def(model) => {
+            this.assertSuccess(k.migrate(model)[0]);
+        });
+
+        const users = k.rawQuery("SELECT name FROM sqlite_master WHERE type='table' AND name='users';");
+        this.assertEquals(users.unwrap()[0][0], 'users');
+
+        const roles = k.rawQuery("SELECT name FROM sqlite_master WHERE type='table' AND name='roles';");
+        this.assertEquals(roles.unwrap()[0][0], 'roles');
+    }
+}
+
+TestKahlessMigrate().run();

--- a/tests/sqlite/update.du
+++ b/tests/sqlite/update.du
@@ -1,0 +1,47 @@
+from UnitTest import UnitTest;
+
+import "../../kahless.du" as kahless;
+
+@Table("users")
+class User < kahless.Model {
+    @Column("first_name")
+    var firstName = "";
+
+    @Column("last_name")
+    var lastName = "";
+
+    @Column("age")
+    var age = 0;
+}
+
+@Table("roles")
+class Role < kahless.Model {
+    var name = "";
+}
+
+const config = kahless.Config("sqlite", ":memory:");
+const k = kahless.Kahless(config);
+
+class TestKahlessUpdate < UnitTest {
+    setUp() {
+        const models = [User(), Role()];
+        k.migrate(...models);
+    }
+
+    testUpdate() {
+        const user = User();
+        user.firstName = "John";
+        user.lastName = "Doe";
+        user.age = 28;
+
+        k.create(user).unwrap();
+
+        user.firstName = "James";
+        k.update(user).unwrap();
+        
+        const fetchedUser = k.rawQuery("SELECT first_name, last_name, age FROM users").unwrap();
+        this.assertEquals(fetchedUser[0], ["James", "Doe", "28"]);
+    }
+}
+
+TestKahlessUpdate().run();


### PR DESCRIPTION
# Summary
- Fix references of `not Success`
- Fix an issue with insert queries where the column names weren't comma separated
- Add the ID to the model on create
- Simplify the annotation field check with [optional chaining](https://dictu-lang.com/docs/classes/#optional-chaining)
- Add tests for migrate / find / create / update
  - Note: I have left delete as todo as I wasn't sure whether this would be `.delete()` on a specific model to delete or if you want it so you can delete many at once for this method (maybe both?) 
  

Can look to get a Dictu template setup for actions too then we could run the tests here as well at some point